### PR TITLE
[fix] Bind IPv6 socket to ::, not ::1

### DIFF
--- a/src/port_checker.rs
+++ b/src/port_checker.rs
@@ -108,7 +108,7 @@ async fn lookup(host: &str) -> io::Result<SocketAddr> {
 async fn send_ping(socket_addr: SocketAddr, ping: Ping) -> io::Result<PingResult> {
     let socket;
     if socket_addr.is_ipv6() {
-        socket = UdpSocket::bind("[::1]:0").await?;
+        socket = UdpSocket::bind("[::]:0").await?;
     } else {
         socket = UdpSocket::bind("0.0.0.0:0").await?;
     }


### PR DESCRIPTION
Typo ends up breaking pings because we're binding to localhost instead of our actual address.